### PR TITLE
refactor: revert PR 1 as we no longer need input_file info

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -340,14 +340,8 @@ impl PartitionColumnProjector {
             )
         }
 
-        // The metadata stored in `file_batch` will be discarded here in the
-        // previous impl so we have to set it again.
-        let metadata = file_batch.schema().metadata().clone();
-        let mut schema = Schema::clone(&self.projected_schema);
-        schema.metadata = metadata;
-
         RecordBatch::try_new_with_options(
-            Arc::new(schema),
+            Arc::clone(&self.projected_schema),
             cols,
             &RecordBatchOptions::new().with_row_count(Some(file_batch.num_rows())),
         )

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -44,7 +44,6 @@ use crate::{
 
 use arrow::datatypes::{DataType, SchemaRef};
 use arrow::error::ArrowError;
-use arrow_schema::Schema;
 use datafusion_physical_expr::{
     EquivalenceProperties, LexOrdering, PhysicalExpr, PhysicalSortExpr,
 };
@@ -475,8 +474,6 @@ struct ParquetOpener {
 impl FileOpener for ParquetOpener {
     fn open(&self, file_meta: FileMeta) -> Result<FileOpenFuture> {
         let file_range = file_meta.range.clone();
-        // The returned path will be relative to the root of the storage
-        let input_file = file_meta.location().to_string();
 
         let file_metrics = ParquetFileMetrics::new(
             self.partition_index,
@@ -601,19 +598,8 @@ impl FileOpener for ParquetOpener {
             let adapted = stream
                 .map_err(|e| ArrowError::ExternalError(Box::new(e)))
                 .map(move |maybe_batch| {
-                    maybe_batch.and_then(|b| {
-                        schema_mapping
-                            .map_batch(b)
-                            .map(|b| {
-                                // Provide the `input_file` info in the metadata
-                                let mut schema = Schema::clone(&b.schema());
-                                schema
-                                    .metadata
-                                    .insert("input_file".to_string(), input_file.clone());
-                                b.with_schema(Arc::new(schema)).expect("Won't go wrong because the new schema is a super set of the old one")
-                            })
-                            .map_err(Into::into)
-                    })
+                    maybe_batch
+                        .and_then(|b| schema_mapping.map_batch(b).map_err(Into::into))
                 });
 
             Ok(adapted.boxed())


### PR DESCRIPTION
Revert PR #1 as in the future, queries will be executed at Shard-level and thus we no longer need a Rolling info, which is provided by this `input_file` metadata.


**Don't merge this** until some necessary changes are made in our repo.