### PR TITLE
refactor: ensure projection includes _seq_doc_id instead of _id

### DIFF
--- a/datafusion/core/src/physical_optimizer/optimizer.rs
+++ b/datafusion/core/src/physical_optimizer/optimizer.rs
@@ -71,7 +71,6 @@ impl PhysicalOptimizer {
             // If there is a output requirement of the query, make sure that
             // this information is not lost across different rules during optimization.
             Arc::new(OutputRequirements::new_add_mode()),
-
             // Disable this optimization rule as:
             // 1. It won't be used in most queries used by us
             // 2. Removal of a doc may invalidate the metadata stored in a Parquet

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -54,11 +54,11 @@ pub fn create_physical_expr(
     if input_schema.fields.len() != input_dfschema.fields().len() {
         // If `input_schema` and `input_dfschema` get different schemas, then
         // there is one case where such a inconsistency is allowed, i.e., the
-        // `input_schema` has an extra `_id` field, which is added by us.
+        // `input_schema` has an extra `_seq_doc_id` field, which is added by us.
 
         // Is this inconsistency made by us, if not, panic
-        let made_by_us = input_schema.field_with_name("_id").is_ok()
-            && input_dfschema.field_with_name(None, "_id").is_err();
+        let made_by_us = input_schema.field_with_name("_seq_doc_id").is_ok()
+            && input_dfschema.field_with_name(None, "_seq_doc_id").is_err();
 
         if !made_by_us {
             return internal_err!(


### PR DESCRIPTION
Change this because we no longer store a full ID (`rolling,seq_doc_id`) in the data file but ONLY the `seq_doc_id` part.